### PR TITLE
ARM64

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,8 +16,8 @@ jobs:
           - windows
           - darwin
         goarch:
-          - "386"
           - amd64
+          - arm64
         exclude:
           - goarch: "386"
             goos: darwin


### PR DESCRIPTION
- **Fixes #2: Releasing with github actions**
- **Not building 386, building arm64**
